### PR TITLE
YOR-6: Add Content Type filter to Search Page

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/search_api.index.node_index.yml
@@ -53,6 +53,14 @@ field_settings:
     dependencies:
       module:
         - node
+  type:
+    label: 'Content type'
+    datasource_id: 'entity:node'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - node
   uid:
     label: uid
     datasource_id: 'entity:node'
@@ -125,6 +133,7 @@ processor_settings:
     fields:
       - field_teaser_text
       - rendered_item
+      - type
   language_with_fallback: {  }
   node_exclude: {  }
   rendered_item: {  }
@@ -159,6 +168,7 @@ processor_settings:
     fields:
       - field_teaser_text
       - rendered_item
+      - type
 tracker_settings:
   default:
     indexing_order: fifo

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -199,6 +199,39 @@ display:
           parse_mode: terms
           conjunction: AND
           fields: {  }
+        type:
+          id: type
+          table: search_api_index_node_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: type
+            fallback: ''
+            multiple: and
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: none
+            fail: empty
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters: {  }
       style:
         type: default

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.search.yml
@@ -228,7 +228,7 @@ display:
           specify_validation: true
           validate:
             type: none
-            fail: empty
+            fail: ignore
           validate_options: {  }
           break_phrase: false
           not: false

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/CoreTwigExtension.php
@@ -73,6 +73,7 @@ class CoreTwigExtension extends AbstractExtension {
       new TwigFunction('getCoreSetting', [$this, 'getCoreSetting']),
       new TwigFunction('getHeaderSetting', [$this, 'getHeaderSetting']),
       new TwigFunction('getUrlType', [$this, 'getUrlType']),
+      new TwigFunction('getQueryParam', [$this, 'getQueryParam']),
     ];
   }
 
@@ -288,6 +289,19 @@ class CoreTwigExtension extends AbstractExtension {
    */
   private function isMailTo($url) {
     return str_starts_with($url, 'mailto:');
+  }
+
+  /**
+   * Retrieve a query parameter from the current request.
+   *
+   * @param string $parameter_name
+   *   The name of the query parameter to retrieve.
+   *
+   * @return mixed
+   *   The value of the query parameter, or null if it does not exist.
+   */
+  public function getQueryParam($parameter_name) {
+    return $this->requestStack->getCurrentRequest()->query->get($parameter_name);
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/ViewsSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/ViewsSettingsForm.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Drupal\ys_core\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form for managing views settings.
+ *
+ * @package Drupal\ys_core\Form
+ */
+class ViewsSettingsForm extends ConfigFormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  final public function __construct(
+    ConfigFactoryInterface $config_factory,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
+    parent::__construct($config_factory);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ys_core_views_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['ys_core.views_settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('ys_core.views_settings');
+
+    $form['#attached']['library'][] = 'core/drupal.vertical-tabs';
+    $form['vertical_tabs'] = [
+      '#type' => 'vertical_tabs',
+      '#default_tab' => 'edit-first',
+    ];
+
+    // Search views settings group.
+    $form['search'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Search View'),
+      '#group' => 'vertical_tabs',
+    ];
+
+    $form['search']['show_content_type_filter'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show the <strong>Content Type</strong> filter '),
+      '#default_value' => $config->get('show_content_type_filter'),
+      '#description' => $this->t('Enable to display the <em>Content Type</em> filter that will be shown on the <em>Search</em> page.'),
+    ];
+
+    $form['search']['content_type_list'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Content Types'),
+      '#default_value' => $config->get('content_type_list') ?? [],
+      '#options' => $this->getContentTypeOptions(),
+      '#description' => $this->t('Select the content types that will be visible in Content Type select filter.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="show_content_type_filter"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('ys_core.views_settings')
+      ->set('show_content_type_filter', $form_state->getValue('show_content_type_filter'))
+      ->set('content_type_list', array_filter($form_state->getValue('content_type_list')))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Gets the content type options.
+   *
+   * @return array
+   *   An associative array of content type machine names and labels.
+   */
+  protected function getContentTypeOptions(): array {
+    /** @var \Drupal\node\NodeTypeInterface $content_types*/
+    $content_types = $this->entityTypeManager
+      ->getStorage('node_type')
+      ->loadMultiple();
+
+    // Create an array of content type labels indexed by their machine names.
+    $options = [];
+    foreach ($content_types as $type) {
+      $options[$type->id()] = $type->label();
+    }
+
+    return $options;
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/ViewsSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/ViewsSettingsForm.php
@@ -66,10 +66,8 @@ class ViewsSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('ys_core.views_settings');
 
-    $form['#attached']['library'][] = 'core/drupal.vertical-tabs';
     $form['vertical_tabs'] = [
       '#type' => 'vertical_tabs',
-      '#default_tab' => 'edit-first',
     ];
 
     // Search views settings group.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/ViewsSettingsForm.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Form/ViewsSettingsForm.php
@@ -25,12 +25,14 @@ class ViewsSettingsForm extends ConfigFormBase {
   /**
    * Constructs the object.
    *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    */
   final public function __construct(
     ConfigFactoryInterface $config_factory,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
   ) {
     parent::__construct($config_factory);
     $this->entityTypeManager = $entity_type_manager;
@@ -79,7 +81,7 @@ class ViewsSettingsForm extends ConfigFormBase {
 
     $form['search']['show_content_type_filter'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Show the <strong>Content Type</strong> filter '),
+      '#title' => $this->t('Show the <strong>Content Type</strong> filter'),
       '#default_value' => $config->get('show_content_type_filter'),
       '#description' => $this->t('Enable to display the <em>Content Type</em> filter that will be shown on the <em>Search</em> page.'),
     ];

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesSearchFormBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesSearchFormBlock.php
@@ -3,6 +3,9 @@
 namespace Drupal\ys_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Adds a search form block.
@@ -13,14 +16,54 @@ use Drupal\Core\Block\BlockBase;
  *   category = @Translation("YaleSites Core"),
  * )
  */
-class YaleSitesSearchFormBlock extends BlockBase {
+class YaleSitesSearchFormBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * Constructs a YaleSitesSearchFormBlock object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $configFactory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $configFactory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
+    $config = $this->configFactory->get('ys_core.views_settings');
+
     return [
       '#theme' => 'ys_search_form',
+      '#show_content_type_filter' => $config->get('show_content_type_filter'),
+      '#content_type_list' => $config->get('content_type_list'),
     ];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesSearchFormBlock.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/src/Plugin/Block/YaleSitesSearchFormBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\ys_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -65,6 +66,13 @@ class YaleSitesSearchFormBlock extends BlockBase implements ContainerFactoryPlug
       '#show_content_type_filter' => $config->get('show_content_type_filter'),
       '#content_type_list' => $config->get('content_type_list'),
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags(): array {
+    return Cache::mergeTags(['config:ys_core.views_settings'], parent::getCacheTags());
   }
 
 }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-search-form.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-search-form.html.twig
@@ -1,7 +1,18 @@
 <form action="/search" method="get" id="page-search-form" accept-charset="UTF-8">
   <div class="form-item form-item-keywords">
-    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="" size="30" maxlength="128" class="form-text">
+    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="" size="30" maxlength="128" class="form-text form-item__textfield">
   </div>
+  {% if show_content_type_filter %}
+    <label for="edit-type" class="form-item__label">Show</label>
+    <div class="form-item__dropdown">
+      <select data-drupal-selector="edit-type" id="edit-type" name="type" class="form-select form-item__select">
+        <option value="all" selected="selected">- All -</option>
+        {% for key, value in content_type_list %}
+          <option value="{{ key }}">{{ value|capitalize }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  {% endif %}
   <div class="form-actions form-wrapper" id="edit-actions--page-search-form">
     <input class="cta form-submit" type="submit" id="edit-submit-search--page-search-form" value="Search">
   </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-search-form.html.twig
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/templates/ys-search-form.html.twig
@@ -1,14 +1,14 @@
 <form action="/search" method="get" id="page-search-form" accept-charset="UTF-8">
   <div class="form-item form-item-keywords">
-    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="" size="30" maxlength="128" class="form-text form-item__textfield">
+    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="{{ getQueryParam('keywords') }}" size="30" maxlength="128" class="form-text form-item__textfield">
   </div>
   {% if show_content_type_filter %}
     <label for="edit-type" class="form-item__label">Show</label>
     <div class="form-item__dropdown">
       <select data-drupal-selector="edit-type" id="edit-type" name="type" class="form-select form-item__select">
-        <option value="all" selected="selected">- All -</option>
+        <option value="all" selected="selected">{{'- All -'|t}}</option>
         {% for key, value in content_type_list %}
-          <option value="{{ key }}">{{ value|capitalize }}</option>
+          <option value="{{ key }}" {% if key == getQueryParam('type') %}selected{% endif %}>{{ value|capitalize }}</option>
         {% endfor %}
       </select>
     </div>

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.links.menu.yml
@@ -40,6 +40,13 @@ ys_core.admin_footer_settings:
   route_name: ys_core.admin_footer_settings
   title: "Footer Settings"
   weight: 20
+# Views settings form.
+ys_core.admin_views_settings:
+  description: "Views settings."
+  parent: ys_core.admin_yalesites
+  route_name: ys_core.admin_views_settings
+  title: "Views Settings"
+  weight: 25
 # main menu edit form.
 ys_core.menu_main_edit:
   description: "Manage main navigation"

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -39,7 +39,10 @@ function ys_core_theme($existing, $type, $theme, $path): array {
       ],
     ],
     'ys_search_form' => [
-      'variables' => [],
+      'variables' => [
+        'show_content_type_filter' => NULL,
+        'content_type_list' => [],
+      ],
     ],
     'ys_title_breadcrumb' => [
       'variables' => [

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.routing.yml
@@ -38,3 +38,11 @@ ys_core.admin_dashboard:
     _title: 'Dashboard'
   requirements:
     _permission: 'yalesites manage settings'
+# Views settings form.
+ys_core.admin_views_settings:
+  path: '/admin/yalesites/views-settings'
+  defaults:
+    _form: '\Drupal\ys_core\Form\ViewsSettingsForm'
+    _title: 'Views Settings'
+  requirements:
+    _permission: 'yalesites manage settings'


### PR DESCRIPTION
## [YOR-6: Add Content Type filter to Search Page](https://ffwagency.atlassian.net/browse/YOR-6)

### Description of work
- Add Content Type filter to Search Page

### Functional testing steps:
- [ ] Ensure Content is Indexed: navigate to /admin/config/search/search-api/index/node_index.
- [ ] Ensure the Content Type filter is enabled from _Views Settings -> Search_ configuration form: navigate to /admin/yalesites/views-settings.
- [ ] Enable the **Show the Content Type filter**.
- [ ] Select all Content Types options.
- [ ] Go to the /search page.
- [ ] Enter a search string in the input field.
- [ ] Select a content type from the newly added select filter.
- [ ] Verify that the search results are filtered according to the selected content type.
