### PR TITLE
YOR-27: Add CTA buttons to Views blocks

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.view.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.view.default.yml
@@ -5,14 +5,34 @@ dependencies:
   config:
     - block_content.type.view
     - field.field.block_content.view.field_heading
+    - field.field.block_content.view.field_heading_links
     - field.field.block_content.view.field_instructions
     - field.field.block_content.view.field_view_params
   module:
     - allowed_formats
+    - field_group
     - markup
     - maxlength
+    - paragraphs
     - text
     - ys_views_basic
+third_party_settings:
+  field_group:
+    group_heading_links:
+      children:
+        - field_heading_links
+      label: 'Heading Link(s)'
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        required_fields: true
+        formatter: closed
 id: block_content.view.default
 targetEntityType: block_content
 bundle: view
@@ -33,6 +53,18 @@ content:
         maxlength_js: 50
         maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
+  field_heading_links:
+    type: entity_reference_paragraphs
+    weight: 4
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
   field_instructions:
     type: markup
     weight: 0
@@ -41,7 +73,7 @@ content:
     third_party_settings: {  }
   field_view_params:
     type: views_basic_default_widget
-    weight: 3
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.view.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.view.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - markup
     - maxlength
     - paragraphs
+    - paragraphs_features
     - text
     - ys_views_basic
 third_party_settings:
@@ -54,17 +55,29 @@ content:
         maxlength_js_label: 'Content recommended length set to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
   field_heading_links:
-    type: entity_reference_paragraphs
+    type: paragraphs
     weight: 4
     region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
+      closed_mode: summary
+      autocollapse: all
+      closed_mode_threshold: 0
       add_mode: button
       form_display_mode: default
       default_paragraph_type: _none
-    third_party_settings: {  }
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings:
+      paragraphs_features:
+        add_in_between: false
+        add_in_between_link_count: 3
+        delete_confirmation: true
+        show_drag_and_drop: true
   field_instructions:
     type: markup
     weight: 0

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.cta_link.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.paragraph.cta_link.default.yml
@@ -1,0 +1,27 @@
+uuid: b3a11376-0019-4623-b759-7568ada12a31
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta_link.field_link
+    - paragraphs.paragraphs_type.cta_link
+  module:
+    - linkit
+id: paragraph.cta_link.default
+targetEntityType: paragraph
+bundle: cta_link
+mode: default
+content:
+  field_link:
+    type: linkit
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.view.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.view.default.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - block_content.type.view
     - field.field.block_content.view.field_heading
+    - field.field.block_content.view.field_heading_links
     - field.field.block_content.view.field_instructions
     - field.field.block_content.view.field_view_params
   module:
+    - entity_reference_revisions
     - text
     - ys_views_basic
 id: block_content.view.default
@@ -22,12 +24,21 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  field_heading_links:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_view_params:
     type: views_basic_default_formatter
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
 hidden:
   field_instructions: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_link.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_link.default.yml
@@ -1,0 +1,28 @@
+uuid: 0114fc18-5dd4-4737-bf9e-ff7c151652f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cta_link.field_link
+    - paragraphs.paragraphs_type.cta_link
+  module:
+    - link
+id: paragraph.cta_link.default
+targetEntityType: paragraph
+bundle: cta_link
+mode: default
+content:
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_link.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_link.default.yml
@@ -13,7 +13,7 @@ bundle: cta_link
 mode: default
 content:
   field_link:
-    type: link
+    type: link_separate
     label: hidden
     settings:
       trim_length: null

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_link.preview.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.paragraph.cta_link.preview.yml
@@ -1,0 +1,29 @@
+uuid: 821a1987-3a55-45c5-ae49-c110e27c269b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.cta_link.field_link
+    - paragraphs.paragraphs_type.cta_link
+  module:
+    - link
+id: paragraph.cta_link.preview
+targetEntityType: paragraph
+bundle: cta_link
+mode: preview
+content:
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_heading_links.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_heading_links.yml
@@ -12,7 +12,7 @@ id: block_content.view.field_heading_links
 field_name: field_heading_links
 entity_type: block_content
 bundle: view
-label: Link
+label: Links
 description: ''
 required: false
 translatable: false
@@ -42,9 +42,6 @@ settings:
         enabled: false
       gallery_item:
         weight: 15
-        enabled: false
-      link:
-        weight: 17
         enabled: false
       link_list:
         weight: 16

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_heading_links.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_heading_links.yml
@@ -1,0 +1,64 @@
+uuid: 50dcc9c5-8991-456d-b9b6-5118a051d9a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.view
+    - field.storage.block_content.field_heading_links
+    - paragraphs.paragraphs_type.cta_link
+  module:
+    - entity_reference_revisions
+id: block_content.view.field_heading_links
+field_name: field_heading_links
+entity_type: block_content
+bundle: view
+label: Link
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      cta_link: cta_link
+    negate: 0
+    target_bundles_drag_drop:
+      accordion_item:
+        weight: 11
+        enabled: false
+      callout_item:
+        weight: 12
+        enabled: false
+      cta_link:
+        weight: 15
+        enabled: true
+      custom_card:
+        weight: 13
+        enabled: false
+      facts_item:
+        weight: 14
+        enabled: false
+      gallery_item:
+        weight: 15
+        enabled: false
+      link:
+        weight: 17
+        enabled: false
+      link_list:
+        weight: 16
+        enabled: false
+      media_grid_item:
+        weight: 17
+        enabled: false
+      tab:
+        weight: 18
+        enabled: false
+      text:
+        weight: 19
+        enabled: false
+      tile:
+        weight: 20
+        enabled: false
+field_type: entity_reference_revisions

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_link.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_link.field_link.yml
@@ -18,6 +18,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  title: 1
+  title: 2
   link_type: 17
 field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_link.field_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.paragraph.cta_link.field_link.yml
@@ -1,0 +1,23 @@
+uuid: ddf0fead-9d6b-4bd9-8f06-3ae3c37fe207
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.cta_link
+  module:
+    - link
+id: paragraph.cta_link.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: cta_link
+label: Link
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_heading_links.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.storage.block_content.field_heading_links.yml
@@ -1,0 +1,21 @@
+uuid: e98c4b01-0de0-4332-acdd-c461d73c6f62
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_heading_links
+field_name: field_heading_links
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/profiles/custom/yalesites_profile/config/sync/paragraphs.paragraphs_type.cta_link.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/paragraphs.paragraphs_type.cta_link.yml
@@ -1,0 +1,35 @@
+uuid: 6d1a287b-3059-49f7-a37e-3890daf91f15
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_redirect
+third_party_settings:
+  entity_redirect:
+    redirect:
+      anonymous:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      add:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      edit:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+      delete:
+        active: false
+        destination: default
+        url: ''
+        external: ''
+id: cta_link
+label: 'CTA Link'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -591,7 +591,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       if (isset($formState->getCompleteForm()['block_form']['#block']) && $formState->getCompleteForm()['block_form']['#block']->isReusable()) {
         // Reusable block Layout Builder form.
         $formSelectors = [
-          'entity_types' => ($rebuildValues) ? $rebuildValues['block_form']['group_user_selection']['entity_and_view_mode']['entity_types'] : $entityValue,
+          'entity_types' => $rebuildValues['block_form']['group_user_selection']['entity_and_view_mode']['entity_types'] ?? $entityValue,
           'entity_types_ajax' => ':input[name="block_form[group_user_selection][entity_and_view_mode][entity_types]"]',
           'view_mode_ajax' => ($form) ? $form['block_form']['group_user_selection']['entity_and_view_mode']['view_mode'] : NULL,
           'massage_terms_include_array' => [
@@ -641,7 +641,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       else {
         // Regular block Layout Builder form.
         $formSelectors = [
-          'entity_types' => ($rebuildValues) ? $rebuildValues['settings']['block_form']['group_user_selection']['entity_and_view_mode']['entity_types'] : $entityValue,
+          'entity_types' => $rebuildValues['settings']['block_form']['group_user_selection']['entity_and_view_mode']['entity_types'] ?? $entityValue,
           'entity_types_ajax' => ':input[name="settings[block_form][group_user_selection][entity_and_view_mode][entity_types]"]',
           'view_mode_ajax' => ($form) ? $form['settings']['block_form']['group_user_selection']['entity_and_view_mode']['view_mode'] : NULL,
           'massage_terms_include_array' => [
@@ -704,7 +704,7 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     else {
       // Drupal core block form.
       $formSelectors = [
-        'entity_types' => ($rebuildValues) ? $rebuildValues['entity_types'] : $entityValue,
+        'entity_types' => $rebuildValues['entity_types'] ?? $entityValue,
         'entity_types_ajax' => ':input[name="entity_types"]',
         'view_mode_ajax' => ($form) ? $form['group_user_selection']['entity_and_view_mode']['view_mode'] : NULL,
         'massage_terms_include_array' => ['terms_include'],


### PR DESCRIPTION
## [YOR-27: Add CTA buttons to Views blocks](https://ffwagency.atlassian.net/browse/YOR-27)

### Description of work
- Add CTA buttons to Views blocks

### Functional testing steps:
- [ ] Add a view
- [ ] Create a **CTA link** from Heading Link(s) fieldset.

