### PR TITLE
YOR-29: Additional CTA links for Spotlight Cards

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.content_spotlight.field_heading
     - field.field.block_content.content_spotlight.field_instructions
     - field.field.block_content.content_spotlight.field_link
+    - field.field.block_content.content_spotlight.field_link_two
     - field.field.block_content.content_spotlight.field_media
     - field.field.block_content.content_spotlight.field_style_color
     - field.field.block_content.content_spotlight.field_style_position
@@ -29,7 +30,7 @@ mode: default
 content:
   field_heading:
     type: text_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 60
@@ -62,9 +63,19 @@ content:
         maxlength_js: null
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
+  field_link_two:
+    type: linkit
+    weight: 7
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
+    third_party_settings: {  }
   field_media:
     type: media_library_widget
-    weight: 1
+    weight: 2
     region: content
     settings:
       media_types: {  }
@@ -73,31 +84,31 @@ content:
         show_edit: '1'
   field_style_color:
     type: options_select
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_position:
     type: options_select
-    weight: 7
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_variation:
     type: options_select
-    weight: 9
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   field_style_width:
     type: options_select
-    weight: 8
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   field_subheading:
     type: text_textfield
-    weight: 3
+    weight: 4
     region: content
     settings:
       size: 60
@@ -112,7 +123,7 @@ content:
         maxlength_js_enforce: false
   field_text:
     type: text_textarea
-    weight: 4
+    weight: 5
     region: content
     settings:
       rows: 5

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.content_spotlight_portrait.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.content_spotlight_portrait.field_heading
     - field.field.block_content.content_spotlight_portrait.field_instructions
     - field.field.block_content.content_spotlight_portrait.field_link
+    - field.field.block_content.content_spotlight_portrait.field_link_two
     - field.field.block_content.content_spotlight_portrait.field_media
     - field.field.block_content.content_spotlight_portrait.field_style_color
     - field.field.block_content.content_spotlight_portrait.field_style_position
@@ -17,6 +18,7 @@ dependencies:
     - allowed_formats
     - hide_revision_field
     - link
+    - linkit
     - markup
     - maxlength
     - media_library
@@ -60,6 +62,19 @@ content:
         maxlength_js: null
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
+  field_link_two:
+    type: linkit
+    weight: 7
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+      linkit_profile: default
+      linkit_auto_link_text: false
+    third_party_settings:
+      maxlength:
+        maxlength_js: null
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   field_media:
     type: media_library_widget
     weight: 3

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.content_spotlight.field_heading
     - field.field.block_content.content_spotlight.field_instructions
     - field.field.block_content.content_spotlight.field_link
+    - field.field.block_content.content_spotlight.field_link_two
     - field.field.block_content.content_spotlight.field_media
     - field.field.block_content.content_spotlight.field_style_color
     - field.field.block_content.content_spotlight.field_style_position
@@ -31,6 +32,18 @@ content:
     weight: 1
     region: content
   field_link:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_link_two:
     type: link_separate
     label: hidden
     settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight_portrait.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.content_spotlight_portrait.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.block_content.content_spotlight_portrait.field_heading
     - field.field.block_content.content_spotlight_portrait.field_instructions
     - field.field.block_content.content_spotlight_portrait.field_link
+    - field.field.block_content.content_spotlight_portrait.field_link_two
     - field.field.block_content.content_spotlight_portrait.field_media
     - field.field.block_content.content_spotlight_portrait.field_style_color
     - field.field.block_content.content_spotlight_portrait.field_style_position
@@ -30,6 +31,18 @@ content:
     weight: 1
     region: content
   field_link:
+    type: link_separate
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_link_two:
     type: link_separate
     label: hidden
     settings:

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_link_two.yml
@@ -1,0 +1,23 @@
+uuid: 4a074e92-fcec-4fa3-8772-248bf7af4262
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_spotlight
+    - field.storage.block_content.field_link_two
+  module:
+    - link
+id: block_content.content_spotlight.field_link_two
+field_name: field_link_two
+entity_type: block_content
+bundle: content_spotlight
+label: 'Call-to-action Two'
+description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight.field_link_two.yml
@@ -11,7 +11,7 @@ id: block_content.content_spotlight.field_link_two
 field_name: field_link_two
 entity_type: block_content
 bundle: content_spotlight
-label: 'Call-to-action Two'
+label: 'Secondary Link'
 description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
 required: false
 translatable: false

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_link_two.yml
@@ -1,0 +1,23 @@
+uuid: 6d97a59e-3b99-4860-b958-645a5b6361f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.content_spotlight_portrait
+    - field.storage.block_content.field_link_two
+  module:
+    - link
+id: block_content.content_spotlight_portrait.field_link_two
+field_name: field_link_two
+entity_type: block_content
+bundle: content_spotlight_portrait
+label: 'Call-to-action Two'
+description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_link_two.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.content_spotlight_portrait.field_link_two.yml
@@ -11,7 +11,7 @@ id: block_content.content_spotlight_portrait.field_link_two
 field_name: field_link_two
 entity_type: block_content
 bundle: content_spotlight_portrait
-label: 'Call-to-action Two'
+label: 'Secondary Link'
 description: 'For more information about linking content, view our resource <a href="https://yalesites.yale.edu/resource-library/linking-content-on-yalesites" target="_blank">Linking Content on YaleSites</a>.'
 required: false
 translatable: false


### PR DESCRIPTION
## [YALB-29: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
-- Add Additional CTA links for Spotlight Cards [**Call-to-action Two**]

Call-to-action Two	
### Functional testing steps:
- [ ]  Adds **Spotlight - Portrait** and **Spotlight - Landscape** blocks
- [ ] Adds value for link field **Call-to-action Two**

