### PR TITLE
YOR-7: Add support for filtering by Year on News (aka Post) lists

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -543,6 +543,51 @@ display:
             title: title
             field_teaser_text: field_teaser_text
             field_teaser_title: field_teaser_title
+        news_year_filter:
+          id: news_year_filter
+          table: node_field_data
+          field: news_year_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: news_year_filter
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: news_year_filter_op
+            label: 'News by Year'
+            description: ''
+            use_operator: false
+            operator: news_year_filter_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: news_year_filter
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              contributor: '0'
+              editor: '0'
+              site_admin: '0'
+              platform_admin: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -234,6 +234,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#type' => 'checkboxes',
       '#options' => [
         'show_search_filter' => $this->t('Show Search Filter'),
+        'show_year_filter' => $this->t('Show Year Filter'),
       ],
       '#title' => $this->t('Exposed Filter Options'),
       '#tree' => TRUE,
@@ -359,19 +360,19 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
 
     $form['field_show_thumbnails']['widget']['value']['#states'] = [
       'invisible' => [
-        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed']
+        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed'],
       ],
     ];
 
     $form['field_show_categories']['widget']['value']['#states'] = [
       'invisible' => [
-        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed']
+        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed'],
       ],
     ];
 
     $form['field_show_tags']['widget']['value']['#states'] = [
       'invisible' => [
-        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed']
+        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed'],
       ],
     ];
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/NewsYearFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/NewsYearFilter.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\ys_views_basic\Plugin\views\filter;
+
+use Drupal\Core\Database\Connection;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\Plugin\views\filter\InOperator;
+use Drupal\views\ViewExecutable;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter news by year.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("news_year_filter")
+ */
+class NewsYearFilter extends InOperator {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $connection;
+
+  /**
+   * Constructs a Handler object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection used by the entity query.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Connection $connection) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->connection = $connection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('database')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
+
+    $this->valueTitle = $this->t('News Year Filter');
+    $this->definition['options callback'] = [$this, 'generateYearOptions'];
+  }
+
+  /**
+   * Generates the options for the filter.
+   *
+   * @return array
+   *   Returns an associative array where the keys and values are years.
+   */
+  public function generateYearOptions(): array {
+    $options = [];
+    // Query to get the minimum year from the publish dates.
+    $query = $this->connection->select('node__field_publish_date', 'nfd')
+      ->fields('nfd', ['field_publish_date_value'])
+      ->condition('bundle', 'post')
+      ->orderBy('field_publish_date_value')
+      ->range(0, 1)
+      ->execute()
+      ->fetchField();
+
+    $min_year = substr($query, 0, 4);
+    $current_year = date('Y');
+    // Generate a range of years from the minimum year to the current year.
+    if ($min_year) {
+      foreach (range($min_year, $current_year) as $year) {
+        $options[$year] = $year;
+      }
+    }
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // If there are no values, do nothing.
+    if (empty($this->value)) {
+      return;
+    }
+    // Ensure the main table for this handler is in the query.
+    $this->ensureMyTable();
+
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
+    $query = $this->query;
+
+    $lookupTable = $query->addTable('node__field_publish_date');
+    $field = "$lookupTable.field_publish_date_value";
+
+    // Prepare the placeholder and conditions.
+    $placeholders = [];
+    $conditions = [];
+
+    // Handle multiple values or single value.
+    if ($this->options['expose']['multiple']) {
+      foreach ($this->value as $index => $year) {
+        $placeholder = ":year_$index";
+        $conditions[] = "$field LIKE $placeholder";
+        $placeholders[$placeholder] = $year . '%';
+      }
+      $condition_expression = implode(' OR ', $conditions);
+    }
+    else {
+      $placeholder = ":year";
+      $conditions[] = "$field LIKE $placeholder";
+      $year = reset($this->value);
+      $placeholders[$placeholder] = $year . '%';
+      $condition_expression = $conditions[0];
+    }
+    // Add the where expression with placeholders.
+    $query->addWhereExpression($this->options['group'], $condition_expression, $placeholders);
+  }
+
+}

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -249,6 +249,12 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       // Set the modified filters back to the view display options.
       $view->getDisplay()->setOption('filters', $filters);
     }
+    if (!isset($paramsDecoded['exposed_filter_options']['show_year_filter'])) {
+      // Remove the 'News by Year' filter if the 'show_year_filter' is not set.
+      unset($filters['news_year_filter']);
+      // Set the modified filters back to the view display options.
+      $view->getDisplay()->setOption('filters', $filters);
+    }
 
     /*
      * Sets the arguments that will get passed to contextual filters as well
@@ -348,8 +354,9 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
       case "rendered":
         $view = $view->preview();
 
-        // Loop through each row in the view's results and update the node's properties
-        // based on show_categories and show_tags configuration, and add the corresponding cache metadata.
+        // Loop through each row in the view's results and update the node's
+        // properties based on show_categories and show_tags configuration,
+        // and add the corresponding cache metadata.
         $show_categories = (int) !empty($paramsDecoded['field_options']['show_categories']);
         $show_tags = (int) !empty($paramsDecoded['field_options']['show_tags']);
         foreach ($view['#rows']['#rows'] as &$resultRow) {

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -58,6 +58,13 @@ function ys_views_basic_views_data_alter(array &$data) {
       'id' => 'event_time_period',
     ],
   ];
+  $data['node_field_data']['news_year_filter'] = [
+    'title' => t('News by Year'),
+    'filter' => [
+      'help' => t('Filter news by year based on publish date.'),
+      'id' => 'news_year_filter',
+    ],
+  ];
 
 }
 


### PR DESCRIPTION
## [YOR-7: Add support for filtering by Year on News (aka Post) lists View blocks](https://ffwagency.atlassian.net/browse/YOR-7)

### Description of work
- Add **News by Year** exposed filter to Views blocks

### Functional testing steps:
- [ ] Add a View and Configure News by Year Filter:
- Navigate to the section where you can add a new view
- Set the values for the Show Year Filter option as shown in the screenshot below:
![image](https://github.com/user-attachments/assets/6ec1f601-8eae-4f0d-832a-b8d211f0cce5)
- [ ] Save Changes:
- Save the configuration
- Verify that the News by Year filter becomes visible for the added View block

**Expected Outcome:**
The Show Year Filter option should be correctly configured and visible in the View block after saving.
