### PR TITLE
YOR-32: Add a "Category" filter to the Views block

### DIFF
--- a/web/profiles/custom/yalesites_profile/composer.json
+++ b/web/profiles/custom/yalesites_profile/composer.json
@@ -128,7 +128,8 @@
         "plural results summary https://www.drupal.org/project/drupal/issues/2888320": "https://www.drupal.org/files/issues/2021-12-15/2888320-78.patch",
         "Add reusable option to inline block creation https://www.drupal.org/project/drupal/issues/2999491": "https://git.drupalcode.org/issue/drupal-2999491/-/commit/1330eff91b1234979cf697a66a48e34eb116b441.patch",
         "Update \"Add reusable option to inline block creation\" patch with local changes to save block if it didn't save": "patches/layout_builder/1330eff91b1234979cf697a66a48e34eb116b441-1.patch",
-        "Prevent empty block_content info fields from causing php deprecation notices": "https://www.drupal.org/files/issues/2023-07-21/3340159-empty-block-label_0.patch"
+        "Prevent empty block_content info fields from causing php deprecation notices": "https://www.drupal.org/files/issues/2023-07-21/3340159-empty-block-label_0.patch",
+        "Ajax exposed filters not working for multiple instances of the same Views block placed on one page" : "https://www.drupal.org/files/issues/2023-05-07/3163299-104-D10.patch"
       },
       "drupal/entity_redirect": {
         "fix layout route https://www.drupal.org/project/entity_redirect/issues/3352265": "https://git.drupalcode.org/project/entity_redirect/-/merge_requests/6.patch"

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_view_params.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.view.field_view_params.yml
@@ -19,7 +19,7 @@ default_value:
   -
     group_params:
       params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null,"event_time_period":"future"},"operator":"+","sort_by":null,"display":null,"limit":0}'
-    params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null,"event_time_period":"future"},"field_options":[],"exposed_filter_options":[],"operator":"+","sort_by":null,"display":null,"limit":0}'
+    params: '{"view_mode":"card","filters":{"types":["post"],"terms_include":null,"terms_exclude":null,"event_time_period":"future"},"field_options":[],"exposed_filter_options":[],"category_filter_label":null,"category_included_terms":null,"operator":"+","sort_by":null,"display":null,"limit":0}'
 default_value_callback: ''
 settings: {  }
 field_type: views_basic_params

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -6,6 +6,8 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.storage.node.field_teaser_text
     - field.storage.node.field_teaser_title
+    - taxonomy.vocabulary.affiliation
+    - taxonomy.vocabulary.post_category
   module:
     - node
     - taxonomy
@@ -588,6 +590,106 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_category_target_id_op
+            label: Category
+            description: ''
+            use_operator: false
+            operator: field_category_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_category_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              contributor: '0'
+              editor: '0'
+              site_admin: '0'
+              platform_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: post_category
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_affiliation_target_id:
+          id: field_affiliation_target_id
+          table: node__field_affiliation
+          field: field_affiliation_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_affiliation_target_id_op
+            label: Affiliation
+            description: ''
+            use_operator: false
+            operator: field_affiliation_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_affiliation_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              contributor: '0'
+              editor: '0'
+              site_admin: '0'
+              platform_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: affiliation
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
       filter_groups:
         operator: AND
         groups:
@@ -626,6 +728,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -648,6 +751,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:

--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold_events.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.storage.node.field_teaser_text
     - field.storage.node.field_teaser_title
+    - taxonomy.vocabulary.event_category
   module:
     - node
     - taxonomy
@@ -543,6 +544,56 @@ display:
             title: title
             field_teaser_text: field_teaser_text
             field_teaser_title: field_teaser_title
+        field_category_target_id:
+          id: field_category_target_id
+          table: node__field_category
+          field: field_category_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_category_target_id_op
+            label: Category
+            description: ''
+            use_operator: false
+            operator: field_category_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_category_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              contributor: '0'
+              editor: '0'
+              site_admin: '0'
+              platform_admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: event_category
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
       filter_groups:
         operator: AND
         groups:
@@ -581,6 +632,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -603,6 +655,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicDefaultFormatter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldFormatter/ViewsBasicDefaultFormatter.php
@@ -119,11 +119,13 @@ class ViewsBasicDefaultFormatter extends FormatterBase implements ContainerFacto
         '#theme' => 'views_basic_formatter_default',
         '#view' => $view,
         // Extract exposed filters from the view and place them separately.
-        // This is necessary because we are conditionally displaying specific exposed filters
-        // based on field configuration. By placing the exposed filters outside
-        // of the view rendering context, we ensure that they do not get re-rendered
-        // when AJAX operations are performed on the view, allowing for better control over
-        // which filters are displayed and maintaining the expected user interface behavior.
+        // This is necessary because we are conditionally displaying
+        // specific exposed filters based on field configuration.
+        // By placing the exposed filters outside of the view rendering
+        // context, we ensure that they do not get re-rendered
+        // when AJAX operations are performed on the view,
+        // allowing for better control over which filters are displayed
+        // and maintaining the expected user interface behavior.
         '#exposed' => $view['#view']->exposed_widgets,
       ];
     }

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -235,10 +235,38 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#options' => [
         'show_search_filter' => $this->t('Show Search Filter'),
         'show_year_filter' => $this->t('Show Year Filter'),
+        'show_category_filter' => $this->t('Show Category Filter'),
       ],
       '#title' => $this->t('Exposed Filter Options'),
       '#tree' => TRUE,
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('exposed_filter_options', $items[$delta]->params) : [],
+    ];
+
+    $form['group_user_selection']['entity_and_view_mode']['category_filter_label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Category Filter Label'),
+      '#description' => $this->t("Enter a custom label for the <strong>Category Filter</strong>. This label will be displayed to users as the filter's name. If left blank, the default label <strong>Category</strong> will be used."),
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('category_filter_label', $items[$delta]->params) : NULL,
+      '#states' => [
+        'visible' => [
+          $formSelectors['show_category_filter_selector'] => ['checked' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['group_user_selection']['entity_and_view_mode']['category_included_terms'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Category Filter - Included Terms'),
+      '#options' => $this->viewsBasicManager->getTaxonomyParents($formSelectors['entity_types'] . '_category'),
+      '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('category_included_terms', $items[$delta]->params) : NULL,
+      '#validated' => 'true',
+      '#prefix' => '<div id="edit-category-included-terms">',
+      '#suffix' => '</div>',
+      '#states' => [
+        'visible' => [
+          $formSelectors['show_category_filter_selector'] => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     $form['group_user_selection']['filter_and_sort']['terms_include'] = [
@@ -416,6 +444,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
         ],
         "field_options" => $form['group_user_selection']['entity_and_view_mode']['field_options']['#value'],
         "exposed_filter_options" => $form['group_user_selection']['entity_and_view_mode']['exposed_filter_options']['#value'],
+        "category_filter_label" => $form['group_user_selection']['entity_and_view_mode']['category_filter_label']['#value'],
+        "category_included_terms" => $form['group_user_selection']['entity_and_view_mode']['category_included_terms']['#value'],
         "operator" => $form['group_user_selection']['filter_and_sort']['term_operator']['#value'],
         "sort_by" => $form_state->getValue($formSelectors['sort_by_array']),
         "display" => $form_state->getValue($formSelectors['display_array']),
@@ -430,7 +460,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
   /**
    * Ajax callback to return only view modes for the specified content type.
    */
-  public function updateOtherSettings(array &$form, FormStateInterface $form_state) {
+  public function updateOtherSettings(array &$form, FormStateInterface $form_state): AjaxResponse {
     $formSelectors = $this->viewsBasicManager->getFormSelectors($form_state, $form);
 
     $response = new AjaxResponse();
@@ -438,6 +468,8 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
     $selector = '.views-basic--view-mode[name="group_user_selection[entity_and_view_mode][view_mode]"]:first';
     $response->addCommand(new InvokeCommand($selector, 'prop', [['checked' => TRUE]]));
     $response->addCommand(new ReplaceCommand('#edit-sort-by', $formSelectors['sort_by_ajax']));
+    $response->addCommand(new ReplaceCommand('#edit-category-included-terms', $formSelectors['category_included_terms_ajax']));
+
     return $response;
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -234,7 +234,7 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       '#type' => 'checkboxes',
       '#options' => [
         'show_search_filter' => $this->t('Show Search Filter'),
-        'show_year_filter' => $this->t('Show Year Filter'),
+        'show_year_filter' => $this->t('Show Year Filter (works only for Posts view)'),
         'show_category_filter' => $this->t('Show Category Filter'),
       ],
       '#title' => $this->t('Exposed Filter Options'),
@@ -254,10 +254,13 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
+    $vocabulary_id = $formSelectors['entity_types'] === 'profile'
+      ? 'affiliation'
+      : $formSelectors['entity_types'] . '_category';
     $form['group_user_selection']['entity_and_view_mode']['category_included_terms'] = [
       '#type' => 'select',
       '#title' => $this->t('Category Filter - Included Terms'),
-      '#options' => $this->viewsBasicManager->getTaxonomyParents($formSelectors['entity_types'] . '_category'),
+      '#options' => $this->viewsBasicManager->getTaxonomyParents($vocabulary_id),
       '#default_value' => ($items[$delta]->params) ? $this->viewsBasicManager->getDefaultParamValue('category_included_terms', $items[$delta]->params) : NULL,
       '#validated' => 'true',
       '#prefix' => '<div id="edit-category-included-terms">',


### PR DESCRIPTION
## [YOR-32: Add a Category filter to the Views block](https://ffwagency.atlassian.net/browse/YOR-32)

### Description of work
- Add **Category** exposed filter to Views blocks

### Functional testing steps:
- [ ] Add a View and configure **Category** exposed filter:
- Navigate to the section where you can add a new view

- Set the values for the **Show Category Filter** option as shown in the screenshot below:
![image](https://github.com/user-attachments/assets/00accf36-cb53-4465-ba2e-770742c4b80b)

- By default, the dropdown should show all taxonomy terms in the Categories Vocab that corresponds with the selected content type. (e.g. Post Category for Posts, Page Category for Pages, Event Category for Events, Profile Affiliation for Profiles, etc).

- If the user selected a parent term in the “Category Filter - Included Terms” field, we should only show terms below that parent term. 

- The label should default to “Category”. If the user provided a value for the “Category Filter Label”, use this value instead.

- After a user hits the “Apply” button, the list of results should be filtered to only show items that have been tagged with that specific taxonomy term.

- User should have the option to multi-select

**Expected Outcome:**
The Show Category Filter option should be correctly configured and visible in the View block after saving.
