### PR TITLE
YOR-34: Add theme dial for Hero Banner in Drupal

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_form_display.block_content.grand_hero.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_link
     - field.field.block_content.grand_hero.field_link_two
     - field.field.block_content.grand_hero.field_media
+    - field.field.block_content.grand_hero.field_style_color
     - field.field.block_content.grand_hero.field_style_position
     - field.field.block_content.grand_hero.field_style_variation
     - field.field.block_content.grand_hero.field_text
@@ -84,6 +85,12 @@ content:
     third_party_settings:
       media_library_edit:
         show_edit: '1'
+  field_style_color:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_style_position:
     type: options_select
     weight: 8

--- a/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/core.entity_view_display.block_content.grand_hero.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.block_content.grand_hero.field_link
     - field.field.block_content.grand_hero.field_link_two
     - field.field.block_content.grand_hero.field_media
+    - field.field.block_content.grand_hero.field_style_color
     - field.field.block_content.grand_hero.field_style_position
     - field.field.block_content.grand_hero.field_style_variation
     - field.field.block_content.grand_hero.field_text
@@ -68,6 +69,13 @@ content:
       link: true
     third_party_settings: {  }
     weight: 0
+    region: content
+  field_style_color:
+    type: list_key
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
   field_style_position:
     type: list_key

--- a/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_color.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/field.field.block_content.grand_hero.field_style_color.yml
@@ -1,0 +1,21 @@
+uuid: b8d0f013-9c0d-410e-9edd-1fbb6c3c2e71
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.grand_hero
+    - field.storage.block_content.field_style_color
+  module:
+    - options
+id: block_content.grand_hero.field_style_color
+field_name: field_style_color
+entity_type: block_content
+bundle: grand_hero
+label: Theme
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ys_themes_default_value_function
+settings: {  }
+field_type: list_string

--- a/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/ys_themes.component_overrides.yml
@@ -105,6 +105,12 @@ grand_hero:
       full: Tall
       reduced: Short
     default: full
+  field_style_color:
+    values:
+      one: One
+      two: Two
+      three: Three
+    default: one
 divider:
   field_style_position:
     values:

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_themes/config/install/ys_themes.component_overrides.yml
@@ -105,6 +105,12 @@ grand_hero:
       full: Tall
       reduced: Short
     default: full
+  field_style_color:
+    values:
+      one: One
+      two: Two
+      three: Three
+    default: one
 divider:
   field_style_position:
     values:


### PR DESCRIPTION
## [YOR-34: Add theme dial for Hero Banner in Drupal](https://ffwagency.atlassian.net/browse/YOR-34)

### Description of work
- Add Theme dial for Grand Hero Block Type

### Functional testing steps:
- [ ] Add a block Grand Hero
- [ ] Select an option from **Theme** field.

![image](https://github.com/user-attachments/assets/699b0b2a-88dc-4e00-ab19-5b9da7a203a3)

[Grand Hero Banner - Storybook](https://yalesites-org.github.io/component-library-twig/?path=/story/molecules-banners--grand-hero-banner&args=bgColor:two)
