### PR TITLE
YOR-9: Add Multiselect support to filters on View blocks

### DIFF
--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_core/ys_core.module
@@ -572,3 +572,27 @@ function ys_core_allow_secret_items(AccountProxy $currentUserSession) {
 function _ys_core_invalidate_media_list() {
   \Drupal::service('cache.render')->invalidateAll();
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter() for views_exposed_form.
+ */
+function ys_core_form_views_exposed_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\views\ViewExecutable $view */
+  $view = $form_state->get('view');
+
+  if (in_array($view->id(), ['views_basic_scaffold', 'views_basic_scaffold_events'])) {
+    // List of form elements to which Chosen should be applied.
+    $chosen_filters = [
+      'field_category_target_id',
+      'field_affiliation_target_id',
+      'news_year_filter',
+    ];
+    // Loop through each specified field and apply Chosen settings if the field
+    // exists.
+    foreach ($chosen_filters as $filter_name) {
+      if (isset($form[$filter_name])) {
+        $form[$filter_name]['#chosen'] = TRUE;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## [YOR-9: Add Multiselect support to filters on View blocks](https://ffwagency.atlassian.net/browse/YOR-9)

### Description of work
-- Add Multiselect support to filters on View blocks

### Functional testing steps:
- [ ] Navigate to the section where you can add a new view:
-- Add a View: Advanced->View

- [ ] Check the checkboxes for **Show Category Filter** and **Show Year Filter** under Exposed Filter Options, as shown in the screenshot below:
  ![image](https://github.com/user-attachments/assets/d1ef92bb-84f1-4d97-8424-4b52561c28bc)
 --The Show Year Filter will be displayed only for **Posts** content.
 
**Expected Outcome:**
 -- The Category and News Year filters should be displayed as multi-select dropdowns styled using the Chosen library.