### PR TITLE
YOR-30: Update the News by Year filter

### DIFF
--- a/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
+++ b/web/profiles/custom/yalesites_profile/config/sync/views.view.views_basic_scaffold.yml
@@ -545,28 +545,28 @@ display:
             title: title
             field_teaser_text: field_teaser_text
             field_teaser_title: field_teaser_title
-        news_year_filter:
-          id: news_year_filter
+        post_year_filter:
+          id: post_year_filter
           table: node_field_data
-          field: news_year_filter
+          field: post_year_filter
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          plugin_id: news_year_filter
+          plugin_id: post_year_filter
           operator: in
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: news_year_filter_op
+            operator_id: post_year_filter_op
             label: 'News by Year'
             description: ''
             use_operator: false
-            operator: news_year_filter_op
+            operator: post_year_filter_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: news_year_filter
+            identifier: post_year_filter
             required: false
             remember: false
             multiple: true

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/Field/FieldWidget/ViewsBasicDefaultWidget.php
@@ -389,24 +389,6 @@ class ViewsBasicDefaultWidget extends WidgetBase implements ContainerFactoryPlug
       ],
     ];
 
-    $form['field_show_thumbnails']['widget']['value']['#states'] = [
-      'invisible' => [
-        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed'],
-      ],
-    ];
-
-    $form['field_show_categories']['widget']['value']['#states'] = [
-      'invisible' => [
-        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed'],
-      ],
-    ];
-
-    $form['field_show_tags']['widget']['value']['#states'] = [
-      'invisible' => [
-        $formSelectors['view_mode_input_selector'] => ['value' => 'condensed'],
-      ],
-    ];
-
     $element['group_params']['params'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Params'),

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/PostYearFilter.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/Plugin/views/filter/PostYearFilter.php
@@ -9,13 +9,13 @@ use Drupal\views\ViewExecutable;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Filter news by year.
+ * Filter posts by year.
  *
  * @ingroup views_filter_handlers
  *
- * @ViewsFilter("news_year_filter")
+ * @ViewsFilter("post_year_filter")
  */
-class NewsYearFilter extends InOperator {
+class PostYearFilter extends InOperator {
 
   /**
    * The database connection.
@@ -59,7 +59,7 @@ class NewsYearFilter extends InOperator {
   public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
     parent::init($view, $display, $options);
 
-    $this->valueTitle = $this->t('News Year Filter');
+    $this->valueTitle = $this->t('Post Year Filter');
     $this->definition['options callback'] = [$this, 'generateYearOptions'];
   }
 

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/src/ViewsBasicManager.php
@@ -284,8 +284,8 @@ class ViewsBasicManager extends ControllerBase implements ContainerInjectionInte
     }
 
     if (!isset($paramsDecoded['exposed_filter_options']['show_year_filter']) || $filterType !== 'post') {
-      // Remove the 'News by Year' filter if the 'show_year_filter' is not set.
-      unset($filters['news_year_filter']);
+      // Remove the 'Year' filter if the 'show_year_filter' is not set.
+      unset($filters['post_year_filter']);
     }
 
     // Set the modified filters back to the view display options.

--- a/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
+++ b/web/profiles/custom/yalesites_profile/modules/custom/ys_views_basic/ys_views_basic.module
@@ -58,11 +58,11 @@ function ys_views_basic_views_data_alter(array &$data) {
       'id' => 'event_time_period',
     ],
   ];
-  $data['node_field_data']['news_year_filter'] = [
-    'title' => t('News by Year'),
+  $data['node_field_data']['post_year_filter'] = [
+    'title' => t('Year'),
     'filter' => [
-      'help' => t('Filter news by year based on publish date.'),
-      'id' => 'news_year_filter',
+      'help' => t('Filter posts by year based on publish date.'),
+      'id' => 'post_year_filter',
     ],
   ];
 


### PR DESCRIPTION
Refactor any instances of the word “News” in the codebase to instead use “Post” since this is actually the name of the content type.

Clean code for unused fields:

- $form['field_show_thumbnails']['widget']['value']['#states']
- $form['field_show_categories']['widget']['value']['#states']
- $form['field_show_tags']['widget']['value']['#states']